### PR TITLE
Fix 'undefined' extension display in list item

### DIFF
--- a/ui/src/components/dashboard/audio_list_item.vue
+++ b/ui/src/components/dashboard/audio_list_item.vue
@@ -82,7 +82,10 @@
       basename: ->
         @audio.url.split('.')[0]
       extension: ->
-        '.' + @audio.url.split('.')[1]
+        if @audio.url.split('.')[1]
+          '.' + @audio.url.split('.')[1]
+        else
+          '&nbsp;(no extension)'
     methods:
       handle_edit_clicked: (e) ->
         e.stopPropagation()


### PR DESCRIPTION
When the user removes the extension from the title (willingly or not), 'undefined' appears as the file extension: http://take.ms/AjKTnu
Fixed version: http://take.ms/c7rpH